### PR TITLE
Add background drawable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ most of them are self-explaining, all colors are *not* Resource Ids, but parsed 
 
 `.setBackgroundColor()` Color
 
+`.setBackgroundResource()` Drawable resource
+
 `.setText()` Charset or IntRes for text
 
 `.setTextColor()` Color or ColorStateList

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="de.mateware.snacky">
-
-    <application
-            android:label="@string/app_name"
-            android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+    package="de.mateware.snacky" />

--- a/library/src/main/java/de/mateware/snacky/Snacky.java
+++ b/library/src/main/java/de/mateware/snacky/Snacky.java
@@ -33,15 +33,19 @@ import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP;
 public class Snacky {
 
     private enum Type {
-        DEFAULT(null, null, null), SUCCESS(Color.parseColor("#388E3C"),
-                                           R.drawable.ic_check_black_24dp,
-                                           Color.WHITE), ERROR(Color.parseColor("#D50000"),
-                                                               R.drawable.ic_clear_black_24dp,
-                                                               Color.WHITE), INFO(Color.parseColor("#3F51B5"),
-                                                                                  R.drawable.ic_info_outline_black_24dp,
-                                                                                  Color.WHITE), WARNING(Color.parseColor("#FFA900"),
-                                                                                                        R.drawable.ic_error_outline_black_24dp,
-                                                                                                        Color.BLACK);
+        DEFAULT(null, null, null),
+        SUCCESS(Color.parseColor("#388E3C"),
+                R.drawable.ic_check_black_24dp,
+                Color.WHITE),
+        ERROR(Color.parseColor("#D50000"),
+                R.drawable.ic_clear_black_24dp,
+                Color.WHITE),
+        INFO(Color.parseColor("#3F51B5"),
+                R.drawable.ic_info_outline_black_24dp,
+                Color.WHITE),
+        WARNING(Color.parseColor("#FFA900"),
+                R.drawable.ic_error_outline_black_24dp,
+                Color.BLACK);
 
         private Integer color;
         private Integer iconResId;
@@ -99,7 +103,8 @@ public class Snacky {
         Snackbar.SnackbarLayout snackbarLayout = (Snackbar.SnackbarLayout) snackbar.getView();
 
         if (builder.backgroundColor == null) builder.backgroundColor = builder.type.getColor();
-        if (builder.backgroundColor != null) snackbarLayout.setBackgroundColor(builder.backgroundColor);
+        if (builder.backgroundResId != null) snackbarLayout.setBackgroundResource(builder.backgroundResId);
+        else if (builder.backgroundColor != null) snackbarLayout.setBackgroundColor(builder.backgroundColor);
 
         TextView actionText = snackbarLayout.findViewById(com.google.android.material.R.id.snackbar_action);
         if (builder.actionTextSize != null) {
@@ -201,6 +206,7 @@ public class Snacky {
         private Drawable             icon                    = null;
         private int                  iconResId               = 0;
         private Integer              backgroundColor         = null;
+        private Integer              backgroundResId         = null;
 
         private Builder() {
         }
@@ -335,6 +341,13 @@ public class Snacky {
 
         public Builder setBackgroundColor(@ColorInt int color) {
             this.backgroundColor = color;
+            this.backgroundResId = null;
+            return this;
+        }
+
+        public Builder setBackgroundResource(@DrawableRes int resId) {
+            this.backgroundResId = resId;
+            this.backgroundColor = null;
             return this;
         }
 

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Snacky</string>
-</resources>


### PR DESCRIPTION
Sometime, we need to custom the Snackbar's background. So I added the setter for background by drawable resource

```
Snacky.builder()
    .setBackgroundResource(R.drawable.shape_background_white_round_corner)
    ...
    .build()
    .show();
```